### PR TITLE
Merge fix/allow-duplicate-weakness into master

### DIFF
--- a/src/Components/Editors/Monsters/MonsterWeaknessesEditor.tsx
+++ b/src/Components/Editors/Monsters/MonsterWeaknessesEditor.tsx
@@ -33,7 +33,6 @@ export class MonsterWeaknessesEditor extends React.PureComponent<IProps, IState>
 
 	public render(): React.ReactNode {
 		const elements = Object.values(Element);
-		const omit = this.props.weaknesses.map(weakness => weakness.element);
 
 		return (
 			<>
@@ -81,7 +80,6 @@ export class MonsterWeaknessesEditor extends React.PureComponent<IProps, IState>
 				{!this.props.readOnly && (
 					<>
 						<Button
-							disabled={omit.length === elements.length}
 							icon="plus"
 							onClick={this.onAddClick}
 							style={{marginTop: 15}}
@@ -103,7 +101,6 @@ export class MonsterWeaknessesEditor extends React.PureComponent<IProps, IState>
 												filterable={false}
 												items={elements}
 												itemTextRenderer={this.renderElementText}
-												omit={omit}
 												onItemSelect={this.onElementSelect}
 												popoverProps={{
 													targetClassName: 'full-width',


### PR DESCRIPTION
## Changelog
- Elements can now appear more than once in a monster's weakness list (i.e. when certain conditions change how weak a monster is to an element).