### PR TITLE
Merge fix/missing-stun-weakness into release/1.2.0

### DIFF
--- a/src/Api/Models/Weapon.ts
+++ b/src/Api/Models/Weapon.ts
@@ -54,6 +54,7 @@ export enum Element {
 	PARALYSIS = 'paralysis',
 	POISON = 'poison',
 	SLEEP = 'sleep',
+	STUN = 'stun',
 	THUNDER = 'thunder',
 	WATER = 'water',
 }

--- a/src/Components/Editors/Weapons/ElementEditor.tsx
+++ b/src/Components/Editors/Weapons/ElementEditor.tsx
@@ -23,6 +23,8 @@ interface IState {
 	type: Element;
 }
 
+const weaponElements = Object.values(Element).filter(element => element !== Element.STUN);
+
 export class ElementEditor extends React.PureComponent<IProps, IState> {
 	public state: Readonly<IState> = {
 		activeElement: null,
@@ -93,7 +95,7 @@ export class ElementEditor extends React.PureComponent<IProps, IState> {
 										<FormGroup label="Element">
 											<Select
 												filterable={false}
-												items={Object.values(Element)}
+												items={weaponElements}
 												itemTextRenderer={this.renderElementText}
 												omit={this.props.elements.map(element => element.type)}
 												onItemSelect={this.onElementSelect}


### PR DESCRIPTION
## Changelog
- "Stun" can now be selected in the weakness and resistance editors on monsters.

Depends on LartTyler/MHWDB-API#96.