### PR TITLE
Merge fix/issue-#34 into release/1.3.1

### DIFF
--- a/src/Components/Editors/Slots.tsx
+++ b/src/Components/Editors/Slots.tsx
@@ -2,13 +2,10 @@ import {Button, Classes, Dialog, FormGroup, Intent} from '@blueprintjs/core';
 import {Select, Table} from '@dbstudios/blueprintjs-components';
 import * as React from 'react';
 import {Slot} from '../../Api/Model';
+import {range} from '../../Utility/array';
 import {Theme, ThemeContext} from '../Contexts/ThemeContext';
 
-export const slotRanks = [
-	1,
-	2,
-	3,
-];
+export const slotRanks = range(1, 4);
 
 interface IProps {
 	slots: Slot[];


### PR DESCRIPTION
## Changelog
- Allow slot ranks up to level 4 to support _Iceborne_ decorations (resolves #34).